### PR TITLE
Update README & ignored files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,6 @@ go/quickstart
 
 #vscode
 .vscode
+
+#frontend
+/frontend/build

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 First create a .env file at the same level as the `.env.example`. Add your `CLIENT_ID` and `API_KEY`
 
 Open two terminals, one for the frontend and one for the backend
+
 #### Backend
 ```bash
 cd ruby
@@ -11,6 +12,9 @@ bundle install
 ```
 
 #### Frontend
+
+_Make sure you have `npm version 7` or later installed._
+
 ```bash
 cd frontend
 npm install


### PR DESCRIPTION
npm v6 caused compiler errors, now README specifies to use v7

If files are built we don't need to commit them