### PR TITLE
Use proxy middleware

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "frontend",
       "version": "0.1.0",
       "dependencies": {
         "@kyper/button": "^3.1.0",
@@ -29,6 +30,7 @@
         "@babel/preset-env": "^7.16.11",
         "@babel/preset-react": "^7.16.7",
         "customize-cra": "^1.0.0",
+        "http-proxy-middleware": "^2.0.6",
         "react-app-rewired": "^2.2.1"
       }
     },
@@ -8298,9 +8300,9 @@
       }
     },
     "node_modules/http-proxy-middleware": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.4.tgz",
-      "integrity": "sha512-m/4FxX17SUvz4lJ5WPXOHDUuCwIqXLfLHs1s0uZ3oYjhoXlx9csYxaOa0ElDEJ+h8Q4iJ1s+lTMbiCa4EXIJqg==",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.6.tgz",
+      "integrity": "sha512-ya/UeJ6HVBYxrgYotAZo1KvPWlgB48kUJLDePFeneHsVujFaW5WNj2NgWCAE//B1Dl02BIfYlpNgBy8Kf8Rjmw==",
       "dependencies": {
         "@types/http-proxy": "^1.17.8",
         "http-proxy": "^1.18.1",
@@ -22171,9 +22173,9 @@
       }
     },
     "http-proxy-middleware": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.4.tgz",
-      "integrity": "sha512-m/4FxX17SUvz4lJ5WPXOHDUuCwIqXLfLHs1s0uZ3oYjhoXlx9csYxaOa0ElDEJ+h8Q4iJ1s+lTMbiCa4EXIJqg==",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.6.tgz",
+      "integrity": "sha512-ya/UeJ6HVBYxrgYotAZo1KvPWlgB48kUJLDePFeneHsVujFaW5WNj2NgWCAE//B1Dl02BIfYlpNgBy8Kf8Rjmw==",
       "requires": {
         "@types/http-proxy": "^1.17.8",
         "http-proxy": "^1.18.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,7 +18,6 @@
     "react-scripts": "5.0.0",
     "web-vitals": "^2.1.4"
   },
-  "proxy": "http://localhost:8000",
   "scripts": {
     "start": "react-app-rewired start",
     "build": "react-app-rewired build",
@@ -50,6 +49,7 @@
     "@babel/preset-env": "^7.16.11",
     "@babel/preset-react": "^7.16.7",
     "customize-cra": "^1.0.0",
+    "http-proxy-middleware": "^2.0.6",
     "react-app-rewired": "^2.2.1"
   }
 }

--- a/frontend/src/setupProxy.js
+++ b/frontend/src/setupProxy.js
@@ -1,0 +1,14 @@
+const { createProxyMiddleware } = require('http-proxy-middleware');
+
+const filter = function (pathname, req) {
+  return pathname.match('/api') || pathname.match('/users/');
+};
+
+module.exports = function(app) {
+  app.use(
+    createProxyMiddleware(filter, {
+      target: 'http://localhost:8000',
+      changeOrigin: true,
+    })
+  );
+};


### PR DESCRIPTION
Sunita was running into an error with the way proxy was set up when running the app using node 18. I found this proxy middleware which provides a different way to set up the local proxy, and I tested and found it works for both node 17 and 18.