### PR TITLE
sunita/remove wait for full aggregation config

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,9 @@ Create a .env file at the same level as the `.env.example`.
 Add your `CLIENT_ID` and `API_KEY`.
 You can find these values in your [MX Client Dashboard][]
 
-## 3. Run the MXquickconnect
+## 3. Run the MXquickconnect app
 
-There are two ways of running MX quickconnect app: with or without Docker.
+There are two ways of running this app: with or without Docker.
 If you would like to orchestrate with Docker, skip to the
 [Run with Docker](#run-with-docker) section below.
 

--- a/README.md
+++ b/README.md
@@ -63,14 +63,6 @@ You can choose to run **one** of the following backend implementations. Once
 started the backend will be running on http://localhost:8000
 
 ---
-##### Backend (Python)
-```bash
-cd python
-pip3 install -r requirements.txt
-./start.sh
-```
-
----
 #### Backend (Ruby)
 
 ```bash
@@ -85,6 +77,14 @@ bundle install
 cd mx-platform-node
 npm install
 npm start
+```
+
+---
+##### Backend (Python)
+```bash
+cd python
+pip3 install -r requirements.txt
+./start.sh
 ```
 
 ---

--- a/frontend/src/components/MXConnectWidget.js
+++ b/frontend/src/components/MXConnectWidget.js
@@ -6,7 +6,7 @@ import { ChevronUp } from '@kyper/icon/ChevronUp'
 import SyntaxHighlighter from 'react-syntax-highlighter';
 import { docco } from 'react-syntax-highlighter/dist/esm/styles/hljs';
 
-function MXConnectWidget({onEvent, widgetUrl}) {
+function MXConnectWidget({ onEvent, widgetUrl }) {
   const [isShowingParams, setIsShowingParams] = useState(false);
 
   useEffect(() => {
@@ -17,7 +17,7 @@ function MXConnectWidget({onEvent, widgetUrl}) {
       // Make sure to remove the post message listener to avoid multiple messages
       window.removeEventListener('message', onPostMessage);
     }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
   const widgetConfig = {
@@ -27,7 +27,6 @@ function MXConnectWidget({onEvent, widgetUrl}) {
       mode: 'verification',
       ui_message_version: 4,
       include_transactions: true,
-      wait_for_full_aggregation: true,
     }
   }
 
@@ -63,7 +62,7 @@ function MXConnectWidget({onEvent, widgetUrl}) {
                 }}
                 width={12}
               />
-            ): (
+            ) : (
               <ChevronDown
                 color="currentColor"
                 height={12}
@@ -76,10 +75,10 @@ function MXConnectWidget({onEvent, widgetUrl}) {
           </Button>
         </div>
       </div>
-      { isShowingParams && (
+      {isShowingParams && (
         <div className='widget-params'>
           <SyntaxHighlighter language="json" style={docco}>
-            { JSON.stringify(widgetConfig, null, 2) }
+            {JSON.stringify(widgetConfig, null, 2)}
           </SyntaxHighlighter>
         </div>
       )}

--- a/mx-platform-aspnet-core/Program.cs
+++ b/mx-platform-aspnet-core/Program.cs
@@ -68,7 +68,6 @@ app.MapPost("/api/get_mxconnect_widget_url", (IConfiguration config, HttpRequest
       widgetType: "connect_widget",
       mode: "verification",
       uiMessageVersion: 4,
-      waitForFullAggregation: true,
       includeTransactions: true
   );
   var widgetRequestBody = new WidgetRequestBody(widgetRequest);

--- a/mx-platform-aspnet-core/mx-platform-aspnet-core.csproj
+++ b/mx-platform-aspnet-core/mx-platform-aspnet-core.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="dotenv.net" Version="3.1.1" />
     <PackageReference Include="Json.NET" Version="1.0.33" />
     <PackageReference Include="JsonSubTypes" Version="1.8.0" />
-    <PackageReference Include="MX.Platform.CSharp" Version="0.8.1" />
+    <PackageReference Include="MX.Platform.CSharp" Version="0.8.2" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="Polly" Version="7.2.2" />
     <PackageReference Include="RestSharp" Version="106.13.0" />

--- a/mx-platform-node/controller.js
+++ b/mx-platform-node/controller.js
@@ -69,7 +69,6 @@ app.post('/api/get_mxconnect_widget_url', async function (request, response) {
         is_mobile_webview: false,
         mode: 'verification',
         ui_message_version: 4,
-        wait_for_full_aggregation: true,
         widget_type: 'connect_widget'
       }
     }

--- a/python/app.py
+++ b/python/app.py
@@ -71,7 +71,6 @@ with mx_platform_python.ApiClient(configuration, 'Accept', 'application/vnd.mx.a
         mode = 'verification',
         ui_message_version = 4,
         include_transactions = True,
-        wait_for_full_aggregation = True,
       )
 
       if current_member_guid:

--- a/ruby/Gemfile.lock
+++ b/ruby/Gemfile.lock
@@ -62,6 +62,7 @@ DEPENDENCIES
   dotenv (~> 2.7)
   httparty (~> 0.20.0)
   mx-platform-ruby
+  rack (>= 2.2.3.1)
   rspec-core
   sinatra
   sinatra-cross_origin (~> 0.3.1)

--- a/ruby/app.rb
+++ b/ruby/app.rb
@@ -95,7 +95,6 @@ post '/api/get_mxconnect_widget_url' do
         mode: 'verification',
         ui_message_version: 4,
         include_transactions: true,
-        wait_for_full_aggregation: true,
         current_member_guid: data['current_member_guid']
       )
     )


### PR DESCRIPTION
The widget config option `wait_for_full_aggregation` gets ignored and the widget always waits for jobs to complete. This change removes the options from all backends and the frontend. 

I also made some minor README updates where I noticed things.