### PR TITLE
Use node v16 so proxy middleware works on all backends

### DIFF
--- a/frontend/.npmrc
+++ b/frontend/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -33,6 +33,10 @@
         "customize-cra": "^1.0.0",
         "http-proxy-middleware": "^2.0.6",
         "react-app-rewired": "^2.2.1"
+      },
+      "engines": {
+        "node": "^16.17.0",
+        "npm": "^8.15.0"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,8 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "engines" : { 
-    "npm" : "^8.15.0",
-    "node" : "^16.17.0"
+    "node" : "^16.0.0"
   },
   "dependencies": {
     "@kyper/button": "^3.1.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,6 +2,10 @@
   "name": "frontend",
   "version": "0.1.0",
   "private": true,
+  "engines" : { 
+    "npm" : "^8.15.0",
+    "node" : "^16.17.0"
+  },
   "dependencies": {
     "@kyper/button": "^3.1.0",
     "@kyper/icon": "^1.8.0",


### PR DESCRIPTION
Fixes issue https://github.com/mxenabled/mx-quickconnect/issues/32

Tested with the other backends and everything works as expected.